### PR TITLE
live odds cli added - see merge notes for use and docs

### DIFF
--- a/live_odds_cli.py
+++ b/live_odds_cli.py
@@ -1,0 +1,328 @@
+import argparse
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+
+# Try to import rich, fail gracefully if not installed
+try:
+    from rich.console import Console
+    from rich.table import Table
+
+    RICH_INSTALLED = True
+except ImportError:
+    RICH_INSTALLED = False
+
+import betfairlightweight
+from betfairlightweight import filters
+
+from whatstheodds.betfair.api_client import setup_betfair_api_client
+
+# --- Define all the markets you want ---
+DESIRED_MARKETS = [
+    # Half-time markets
+    "HALF_TIME",
+    "FIRST_HALF_GOALS_05",
+    "FIRST_HALF_GOALS_15",
+    "FIRST_HALF_GOALS_25",
+    "HALF_TIME_SCORE",
+    # Full-time markets
+    "MATCH_ODDS",
+    "OVER_UNDER_05",
+    "OVER_UNDER_15",
+    "OVER_UNDER_25",
+    "OVER_UNDER_35",
+    "CORRECT_SCORE",
+    "BOTH_TEAMS_TO_SCORE",
+]
+
+
+def load_filter_teams(filter_files):
+    """Loads team names from specified JSON files in the 'mapping' directory."""
+    if not filter_files:
+        return None
+
+    allowed_teams = set()
+    base_path = Path("/home/james/bet_project/whatstheodds/mappings/")
+    for file_name in filter_files:
+        file_path = base_path / f"{file_name}.json"
+        if file_path.exists():
+            with open(file_path, "r") as f:
+                data = json.load(f)
+                # We use the values from the mapping, as requested
+                allowed_teams.update(data.values())
+            print(f"Loaded {len(data)} teams from '{file_path}'")
+        else:
+            print(f"Warning: Filter file not found at '{file_path}'")
+    return allowed_teams
+
+
+def list_todays_games(trading, soccer_event_type_id, filter_teams):
+    """Fetches and prints soccer games for today, with optional team filtering."""
+    print("\nFinding today's soccer matches...")
+    now = datetime.utcnow()
+    start_of_day = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    end_of_day = start_of_day + timedelta(days=1)
+    time_filter = filters.time_range(from_=start_of_day, to=end_of_day)
+
+    events = trading.betting.list_events(
+        filter=filters.market_filter(
+            event_type_ids=[soccer_event_type_id], market_start_time=time_filter
+        )
+    )
+
+    if not events:
+        print("No soccer matches found for today.")
+        return
+
+    filtered_events = []
+    if filter_teams:
+        for event_result in events:
+            # Check if either team in "Team A v Team B" is in our filter list
+            teams = [team.strip() for team in event_result.event.name.split(" v ")]
+            if any(team in filter_teams for team in teams):
+                filtered_events.append(event_result)
+    else:
+        filtered_events = events
+
+    if not filtered_events:
+        print("No matches found for today with the specified filter.")
+        return
+
+    print(f"Found {len(filtered_events)} matches:")
+    for event_result in sorted(filtered_events, key=lambda e: e.event.open_date):
+        event = event_result.event
+        print(f"  - {event.open_date.strftime('%H:%M')} | {event.name}")
+
+
+def get_market_odds(trading, soccer_event_type_id, event_name, output_format):
+    """Fetches odds and directs them to the correct display/output function."""
+    print(f"Searching for event: '{event_name}'")
+    events = trading.betting.list_events(
+        filter=filters.market_filter(
+            event_type_ids=[soccer_event_type_id], text_query=event_name
+        )
+    )
+    if not events:
+        print(f"Could not find any events for '{event_name}'")
+        return
+
+    event = events[0].event
+    print(f"Found Event: {event.name}, ID: {event.id}")
+
+    market_catalogues = trading.betting.list_market_catalogue(
+        filter=filters.market_filter(
+            event_ids=[event.id], market_type_codes=DESIRED_MARKETS
+        ),
+        market_projection=[
+            "RUNNER_DESCRIPTION",
+            "MARKET_START_TIME",
+            "MARKET_DESCRIPTION",
+        ],
+        max_results=100,
+    )
+
+    if not market_catalogues:
+        print(f"Could not find any desired markets for {event.name}")
+        return
+
+    market_books = []
+    print(f"Found {len(market_catalogues)} markets. Fetching odds individually...")
+    for catalogue in market_catalogues:
+        # Fetching odds for each market ID individually is the safest way to avoid TOO_MUCH_DATA
+        book = trading.betting.list_market_book(
+            market_ids=[catalogue.market_id],
+            price_projection=filters.price_projection(
+                price_data=filters.price_data(ex_all_offers=True)
+            ),
+        )
+        if book:
+            market_books.extend(book)
+
+    # Build an intermediate, universal data structure first
+    results = {"event_name": event.name, "event_id": event.id, "markets": []}
+    catalogue_map = {mc.market_id: mc for mc in market_catalogues}
+
+    for market_book in market_books:
+        market_catalogue = catalogue_map.get(market_book.market_id)
+        market_data = {
+            "market_name": market_catalogue.market_name,
+            "market_id": market_book.market_id,
+            "market_type": market_catalogue.description.market_type,
+            "runners": [],
+        }
+        for runner in market_book.runners:
+            runner_name = next(
+                (
+                    r.runner_name
+                    for r in market_catalogue.runners
+                    if r.selection_id == runner.selection_id
+                ),
+                "Unknown",
+            )
+            runner_data = {"runner_name": runner_name, "back": None, "lay": None}
+            if runner.ex.available_to_back:
+                best_back = runner.ex.available_to_back[0]
+                runner_data["back"] = {
+                    "price": best_back.price,
+                    "size": round(best_back.size, 2),
+                }
+            if runner.ex.available_to_lay:
+                best_lay = runner.ex.available_to_lay[0]
+                runner_data["lay"] = {
+                    "price": best_lay.price,
+                    "size": round(best_lay.size, 2),
+                }
+            market_data["runners"].append(runner_data)
+        results["markets"].append(market_data)
+
+    # Direct to the correct output based on the format argument
+    if output_format == "dict":
+        nested_dict = transform_to_nested_dict(results)
+        print(json.dumps(nested_dict, indent=2))
+    elif output_format == "pretty":
+        if RICH_INSTALLED:
+            display_pretty_results(results)
+        else:
+            print("\n'rich' library not installed. Falling back to simple display.")
+            print("Install it with: pip install rich")
+            display_simple_results(results)
+    else:  # "simple" or default
+        display_simple_results(results)
+
+
+def display_simple_results(results):
+    """Prints results in a simple, human-readable format."""
+    print(f"\n{'='*40}\nEvent: {results['event_name']}\n{'='*40}\n")
+    for market in results["markets"]:
+        print(f"--- Market: {market['market_name']} ---")
+        for runner in market["runners"]:
+            print(f"  - {runner['runner_name']}:")
+            back_info = runner.get("back")
+            lay_info = runner.get("lay")
+            print(
+                f"    - Back: Price={back_info['price']}, Size=£{back_info['size']:.2f}"
+            )
+            print(
+                f"    - Lay:  Price={lay_info['price']}, Size=£{lay_info['size']:.2f}"
+            )
+            # print(f"    - Back: {'Price=' + str(back_info['price']) + ', Size=£' + f'{back_info["size"]:.2f}' if back_info else 'No odds'}")
+            # print(f"    - Lay:  {'Price=' + str(lay_info['price']) + ', Size=£' + f'{lay_info["size"]:.2f}' if lay_info else 'No odds'}")
+        print("-" * 30 + "\n")
+
+
+def display_pretty_results(results):
+    """Prints results in a rich table format."""
+    console = Console()
+    console.rule(f"[bold cyan]Event: {results['event_name']}", style="cyan")
+    for market in results["markets"]:
+        table = Table(
+            title=f"Market: {market['market_name']}",
+            title_style="magenta",
+            show_header=True,
+            header_style="bold blue",
+        )
+        table.add_column("Runner", style="white", min_width=20)
+        table.add_column("Back Price", justify="right", style="cyan")
+        table.add_column("Back Size (£)", justify="right", style="cyan")
+        table.add_column("Lay Price", justify="right", style="yellow")
+        table.add_column("Lay Size (£)", justify="right", style="yellow")
+
+        for runner in market["runners"]:
+            back_price = f"{runner['back']['price']:.2f}" if runner["back"] else "N/A"
+            back_size = f"{runner['back']['size']:.2f}" if runner["back"] else "N/A"
+            lay_price = f"{runner['lay']['price']:.2f}" if runner["lay"] else "N/A"
+            lay_size = f"{runner['lay']['size']:.2f}" if runner["lay"] else "N/A"
+            table.add_row(
+                runner["runner_name"], back_price, back_size, lay_price, lay_size
+            )
+
+        console.print(table)
+
+
+def transform_to_nested_dict(results):
+    """Transforms the flat result structure into the requested nested dictionary."""
+    output = {}
+    for market in results["markets"]:
+        market_type_str = market["market_type"]
+        period = "ht" if "HALF" in market_type_str else "ft"
+
+        if period not in output:
+            output[period] = {}
+
+        market_name = market["market_name"]
+        if market_name not in output[period]:
+            output[period][market_name] = {}
+
+        for runner in market["runners"]:
+            runner_name = runner["runner_name"]
+            output[period][market_name][runner_name] = {
+                "back": runner.get("back"),
+                "lay": runner.get("lay"),
+            }
+    return output
+
+
+def main():
+    """Main function to parse arguments and execute commands."""
+    parser = argparse.ArgumentParser(description="Betfair Odds CLI Tool for Soccer")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # Sub-parser for the "list" command
+    parser_list = subparsers.add_parser("list", help="List soccer matches for today.")
+    parser_list.add_argument(
+        "-f",
+        "--filter",
+        nargs="+",
+        help="Filter by country using mapping files (e.g., 'scotland' 'england').",
+    )
+
+    # Sub-parser for the "odds" command
+    parser_odds = subparsers.add_parser("odds", help="Get odds for a specific match.")
+    parser_odds.add_argument(
+        "event_name",
+        nargs="+",
+        help="The name of the event (e.g., 'Liverpool v Everton').",
+    )
+    output_group = parser_odds.add_mutually_exclusive_group()
+    output_group.add_argument(
+        "-d",
+        "--dict",
+        action="store_const",
+        dest="output_format",
+        const="dict",
+        help="Output as a nested dictionary (JSON).",
+    )
+    output_group.add_argument(
+        "-p",
+        "--pretty",
+        action="store_const",
+        dest="output_format",
+        const="pretty",
+        help="Display results in a rich table.",
+    )
+    parser_odds.set_defaults(output_format="simple")
+
+    args = parser.parse_args()
+
+    trading = setup_betfair_api_client()
+    try:
+        soccer_event_type_id = trading.betting.list_event_types(
+            filter=filters.market_filter(text_query="Soccer")
+        )[0].event_type.id
+
+        if args.command == "list":
+            filter_teams = load_filter_teams(args.filter)
+            list_todays_games(trading, soccer_event_type_id, filter_teams)
+        elif args.command == "odds":
+            event_name = " ".join(args.event_name)
+            get_market_odds(
+                trading, soccer_event_type_id, event_name, args.output_format
+            )
+
+    finally:
+        trading.logout()
+        print("Logged out.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/whatstheodds/live_odds/live_odds_cli.py
+++ b/src/whatstheodds/live_odds/live_odds_cli.py
@@ -1,0 +1,216 @@
+import argparse
+import json
+from datetime import datetime, timedelta
+
+import betfairlightweight
+from betfairlightweight import filters
+
+from whatstheodds.betfair.api_client import setup_betfair_api_client
+
+# --- 1. Define all the markets you want ---
+DESIRED_MARKETS = [
+    # Half-time markets
+    # "HALF_TIME",
+    # "FIRST_HALF_GOALS_05",
+    # "FIRST_HALF_GOALS_15",
+    # "FIRST_HALF_GOALS_25",
+    # "HALF_TIME_SCORE",
+    # Full-time markets
+    "MATCH_ODDS",
+    "OVER_UNDER_05",
+    "OVER_UNDER_15",
+    "OVER_UNDER_25",
+    "OVER_UNDER_35",
+    "CORRECT_SCORE",
+    "BOTH_TEAMS_TO_SCORE",
+]
+
+
+def list_todays_games(trading, soccer_event_type_id):
+    """Fetches and prints all soccer games scheduled for today."""
+    print("Finding today's soccer matches...")
+
+    # Define time range for today (UTC)
+    now = datetime.utcnow()
+    start_of_day = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    end_of_day = start_of_day + timedelta(days=1)
+
+    time_filter = filters.time_range(from_=start_of_day, to=end_of_day)
+
+    events = trading.betting.list_events(
+        filter=filters.market_filter(
+            event_type_ids=[soccer_event_type_id],
+            market_start_time=time_filter,
+        )
+    )
+
+    if not events:
+        print("No soccer matches found for today.")
+        return
+
+    print(f"Found {len(events)} matches today:")
+    for event_result in sorted(events, key=lambda e: e.event.open_date):
+        event = event_result.event
+        print(f"  - {event.open_date.strftime('%H:%M')} | {event.name}")
+
+
+def get_market_odds(trading, soccer_event_type_id, event_name, as_dict):
+    """Fetches and displays odds for a specific event."""
+    print(f"Searching for event: '{event_name}'")
+    events = trading.betting.list_events(
+        filter=filters.market_filter(
+            event_type_ids=[soccer_event_type_id], text_query=event_name
+        )
+    )
+
+    if not events:
+        print(f"Could not find any events for '{event_name}'")
+        return
+
+    event = events[0].event
+    print(f"Found Event: {event.name}, ID: {event.id}")
+
+    market_catalogues = trading.betting.list_market_catalogue(
+        filter=filters.market_filter(
+            event_ids=[event.id], market_type_codes=DESIRED_MARKETS
+        ),
+        market_projection=["RUNNER_DESCRIPTION"],
+        max_results=100,
+    )
+
+    if not market_catalogues:
+        print(f"Could not find any desired markets for {event.name}")
+        return
+
+    market_ids = [market.market_id for market in market_catalogues]
+    market_books = trading.betting.list_market_book(
+        market_ids=market_ids,
+        price_projection=filters.price_projection(
+            price_data=filters.price_data(ex_all_offers=True)
+        ),
+    )
+
+    catalogue_map = {mc.market_id: mc for mc in market_catalogues}
+    results = {"event_name": event.name, "event_id": event.id, "markets": []}
+
+    for market_book in market_books:
+        market_catalogue = catalogue_map.get(market_book.market_id)
+        market_data = {
+            "market_name": market_catalogue.market_name,
+            "market_id": market_book.market_id,
+            "runners": [],
+        }
+
+        for runner in market_book.runners:
+            runner_name = next(
+                (
+                    r.runner_name
+                    for r in market_catalogue.runners
+                    if r.selection_id == runner.selection_id
+                ),
+                "Unknown Runner",
+            )
+            runner_data = {"runner_name": runner_name, "back": None, "lay": None}
+
+            if runner.ex.available_to_back:
+                best_back = runner.ex.available_to_back[0]
+                runner_data["back"] = {
+                    "price": best_back.price,
+                    "size": round(best_back.size, 2),
+                }
+
+            if runner.ex.available_to_lay:
+                best_lay = runner.ex.available_to_lay[0]
+                runner_data["lay"] = {
+                    "price": best_lay.price,
+                    "size": round(best_lay.size, 2),
+                }
+
+            market_data["runners"].append(runner_data)
+        results["markets"].append(market_data)
+
+    if as_dict:
+        print(json.dumps(results, indent=2))
+    else:
+        display_results(results)
+
+
+def display_results(results):
+    """Prints results in a human-readable format."""
+    print("\n" + "=" * 40)
+    print(f"Event: {results['event_name']}")
+    print("=" * 40 + "\n")
+
+    for market in results["markets"]:
+        print(f"--- Market: {market['market_name']} ---")
+        for runner in market["runners"]:
+            print(f"  - {runner['runner_name']}:")
+            back_info = runner.get("back")
+            lay_info = runner.get("lay")
+
+            if back_info:
+                print(
+                    f"    - Back: Price={back_info['price']}, Size=£{back_info['size']:.2f}"
+                )
+            else:
+                print("    - Back: No odds available")
+
+            if lay_info:
+                print(
+                    f"    - Lay:  Price={lay_info['price']}, Size=£{lay_info['size']:.2f}"
+                )
+            else:
+                print("    - Lay:  No odds available")
+        print("-" * 30 + "\n")
+
+
+def main():
+    """Main function to parse arguments and execute commands."""
+    parser = argparse.ArgumentParser(description="Betfair Odds CLI Tool for Soccer")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # Sub-parser for the "list" command
+    parser_list = subparsers.add_parser(
+        "list", help="List all soccer matches for today."
+    )
+
+    # Sub-parser for the "odds" command
+    parser_odds = subparsers.add_parser("odds", help="Get odds for a specific match.")
+    parser_odds.add_argument(
+        "event_name",
+        nargs="+",
+        help="The name of the event (e.g., 'Liverpool v Everton').",
+    )
+    parser_odds.add_argument(
+        "-d",
+        "--dict",
+        action="store_true",
+        help="Output the results as a dictionary (JSON).",
+    )
+
+    args = parser.parse_args()
+
+    # --- Setup API client and Login ---
+    trading = setup_betfair_api_client()
+    try:
+        # trading.login()
+        # --- Find Soccer Event Type ID ---
+        soccer_event_type = trading.betting.list_event_types(
+            filter=filters.market_filter(text_query="Soccer")
+        )[0]
+        soccer_event_type_id = soccer_event_type.event_type.id
+
+        # --- Execute Command ---
+        if args.command == "list":
+            list_todays_games(trading, soccer_event_type_id)
+        elif args.command == "odds":
+            event_name = " ".join(args.event_name)
+            get_market_odds(trading, soccer_event_type_id, event_name, args.dict)
+
+    finally:
+        trading.logout()
+        print("Logged out.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/whatstheodds/live_odds/test_live_odds.py
+++ b/src/whatstheodds/live_odds/test_live_odds.py
@@ -1,0 +1,107 @@
+import os
+
+import betfairlightweight
+from betfairlightweight import filters
+
+from whatstheodds.betfair.api_client import setup_betfair_api_client
+from whatstheodds.utils import load_config
+
+# --- 1. Set up your credentials ---
+# --- 2. Create the API client and Login ---
+trading = setup_betfair_api_client()
+
+# Login
+# Use login_interactive() if you don't have SSL certificates
+# See the quickstart guide for more details
+# --- 3. Find the Event Type for Soccer ---
+# We want to find the event type for Soccer to filter our search
+soccer_event_type = trading.betting.list_event_types(
+    filter=filters.market_filter(text_query="Soccer")
+)
+print(soccer_event_type)
+# Check if we found the event type
+if not soccer_event_type:
+    print("Could not find event type for Soccer.")
+else:
+    soccer_event_type_id = soccer_event_type[0].event_type.id
+    print(f"Found Soccer Event Type ID: {soccer_event_type_id}")
+
+    # --- 4. Find the Event (the match) ---
+    # Now, let's find a specific match. Replace "Team A" and "Team B" with the teams you are interested in.
+    # For example, "Arsenal v Man City"
+    team_name = "Liverpool v Everton"  # Replace with the team you are looking for
+
+    events = trading.betting.list_events(
+        filter=filters.market_filter(
+            event_type_ids=[soccer_event_type_id], text_query=team_name
+        )
+    )
+
+    if not events:
+        print(f"Could not find any events for '{team_name}'")
+    else:
+        print(f"Found {len(events)} events for '{team_name}':")
+        for event in events:
+            print(f"- Event: {event.event.name}, ID: {event.event.id}")
+
+            # --- 5. Get the Market Catalogue for the Match Odds ---
+            # Now we find the "Match Odds" market for the event.
+            market_catalogues = trading.betting.list_market_catalogue(
+                filter=filters.market_filter(
+                    event_ids=[event.event.id], market_type_codes=["MATCH_ODDS"]
+                ),
+                market_projection=["RUNNER_DESCRIPTION", "MARKET_START_TIME"],
+                max_results=1,
+            )
+
+            if not market_catalogues:
+                print(f"  - Could not find 'Match Odds' market for {event.event.name}")
+            else:
+                market = market_catalogues[0]
+                print(f"  - Found Market: {market.market_name}, ID: {market.market_id}")
+
+                # --- 6. Get the Market Book (the odds) ---
+                market_books = trading.betting.list_market_book(
+                    market_ids=[market.market_id],
+                    price_projection=filters.price_projection(
+                        price_data=filters.price_data(ex_all_offers=True)
+                    ),
+                )
+
+                if not market_books:
+                    print(f"    - Could not get market book for {market.market_name}")
+                else:
+                    market_book = market_books[0]
+                    print("    - Odds:")
+                    for runner in market_book.runners:
+                        # Find the runner in the market catalogue to get the name
+                        runner_name = ""
+                        for r in market.runners:
+                            if r.selection_id == runner.selection_id:
+                                runner_name = r.runner_name
+                                break
+                        print(f"      - {runner_name}:")
+                        # -- Back Odds --
+                        if runner.ex.available_to_back:
+                            # Get the best available back price (the first one in the list)
+                            best_back = runner.ex.available_to_back[0]
+                            print(
+                                f"        - Best Back Price: {best_back.price}, Size: £{best_back.size:.2f}"
+                            )
+                        else:
+                            print("        - No back odds available")
+
+                        # -- Lay Odds --
+                        if runner.ex.available_to_lay:
+                            # Get the best available lay price (the first one in the list)
+                            best_lay = runner.ex.available_to_lay[0]
+                            print(
+                                f"        - Best Lay Price: {best_lay.price}, Size: £{best_lay.size:.2f}"
+                            )
+                        else:
+                            print("        - No lay odds available")
+
+
+# --- 7. Logout ---
+trading.logout()
+print("Logged out.")

--- a/src/whatstheodds/live_odds/test_live_odds_extended_markets.py
+++ b/src/whatstheodds/live_odds/test_live_odds_extended_markets.py
@@ -1,0 +1,113 @@
+import os
+
+import betfairlightweight
+from betfairlightweight import filters
+
+# --- Helper function for cleaner setup (assuming you have this) ---
+from whatstheodds.betfair.api_client import setup_betfair_api_client
+
+# --- 1. Set up your credentials & API client ---
+trading = setup_betfair_api_client()
+
+# --- 2. Define the markets you want ---
+# A list of all market types to search for
+DESIRED_MARKETS = [
+    "MATCH_ODDS",
+    "OVER_UNDER_05",
+    "OVER_UNDER_15",
+    "OVER_UNDER_25",
+    "OVER_UNDER_35",
+    "CORRECT_SCORE",
+    "BOTH_TEAMS_TO_SCORE",
+]
+
+# --- 3. Find the Event Type for Soccer ---
+soccer_event_type = trading.betting.list_event_types(
+    filter=filters.market_filter(text_query="Soccer")
+)
+
+if not soccer_event_type:
+    print("Could not find event type for Soccer.")
+else:
+    soccer_event_type_id = soccer_event_type[0].event_type.id
+    print(f"Found Soccer Event Type ID: {soccer_event_type_id}")
+
+    # --- 4. Find the Event (the match) ---
+    team_name = "Dundee v Livingston"  # Replace with the team you are looking for
+
+    events = trading.betting.list_events(
+        filter=filters.market_filter(
+            event_type_ids=[soccer_event_type_id], text_query=team_name
+        )
+    )
+
+    if not events:
+        print(f"Could not find any events for '{team_name}'")
+    else:
+        # Assuming we only want the first event found
+        event = events[0]
+        print(f"Found Event: {event.event.name}, ID: {event.event.id}\n")
+
+        # --- 5. Get Market Catalogues for ALL desired markets ---
+        market_catalogues = trading.betting.list_market_catalogue(
+            filter=filters.market_filter(
+                event_ids=[event.event.id],
+                market_type_codes=DESIRED_MARKETS,  # Use the list of markets here
+            ),
+            market_projection=["RUNNER_DESCRIPTION"],
+            max_results=100,  # Increase max_results to get all markets
+        )
+
+        if not market_catalogues:
+            print(f"Could not find any of the desired markets for {event.event.name}")
+        else:
+            # Create a list of all market IDs
+            market_ids = [market.market_id for market in market_catalogues]
+
+            # --- 6. Get Market Books (the odds) for ALL markets in one call ---
+            market_books = trading.betting.list_market_book(
+                market_ids=market_ids,
+                price_projection=filters.price_projection(
+                    price_data=filters.price_data(ex_all_offers=True)
+                ),
+            )
+
+            # Create a mapping from market_id to market_catalogue for easy lookup
+            catalogue_map = {mc.market_id: mc for mc in market_catalogues}
+
+            # --- 7. Loop through and display each market book ---
+            for market_book in market_books:
+                market_catalogue = catalogue_map.get(market_book.market_id)
+                print(f"--- Market: {market_catalogue.market_name} ---")
+
+                for runner in market_book.runners:
+                    # Find the runner's name from the catalogue
+                    runner_name = ""
+                    for r in market_catalogue.runners:
+                        if r.selection_id == runner.selection_id:
+                            runner_name = r.runner_name
+                            break
+
+                    print(f"  - {runner_name}:")
+                    # -- Back Odds --
+                    if runner.ex.available_to_back:
+                        best_back = runner.ex.available_to_back[0]
+                        print(
+                            f"    - Back: Price={best_back.price}, Size=£{best_back.size:.2f}"
+                        )
+                    else:
+                        print("    - Back: No odds available")
+
+                    # -- Lay Odds --
+                    if runner.ex.available_to_lay:
+                        best_lay = runner.ex.available_to_lay[0]
+                        print(
+                            f"    - Lay:  Price={best_lay.price}, Size=£{best_lay.size:.2f}"
+                        )
+                    else:
+                        print("    - Lay:  No odds available")
+                print("-" * 30 + "\n")  # Separator for clarity
+
+# --- 8. Logout ---
+trading.logout()
+print("Logged out.")


### PR DESCRIPTION
Feature: Enhanced CLI for Live Soccer Odds

PR Summary: This pull request significantly expands the capabilities of the live_odds.py script, transforming it from a basic proof-of-concept into a powerful command-line interface (CLI) for fetching and displaying live soccer odds from Betfair.

It introduces new commands, multiple output formats, and intelligent filtering, while also addressing critical API limitations that were causing errors.
Key Features & Enhancements
1. New Command-Line Interface

The script now uses argparse to provide a structured and user-friendly CLI with two main commands:

    list: Discovers and lists all available soccer matches for the current day.

    odds: Fetches and displays odds for a specific match across a wide range of pre-defined markets.

2. Multiple Output Formats

The odds command now supports three distinct output formats, making it versatile for both human viewing and programmatic use:

    Simple Text (Default): A clean, easy-to-read text-based display.

    Pretty Tables (-p, --pretty):  A visually appealing table-based output, powered by the rich library.

    Dictionary (-d, --dict): A nested JSON output structured by period (ft/ht), market, and runner. Ideal for piping into other applications or scripts.

3. Smart Filtering for Game Lists

The list command can now be filtered to show only matches for specific leagues or nations using simple JSON mapping files.

    Usage: The -f or --filter flag accepts one or more filter names (e.g., scotland, england).

    Mechanism: The script loads team names from corresponding files in the /mapping directory (e.g., /mapping/scotland.json) and displays only the events that feature a team from that list.

How to Use the New CLI

Prerequisites:

    Ensure the rich library is installed for pretty-table output: pip install rich

    Ensure your team mapping files are in the /mapping directory.

1. List Today's Matches

# List all soccer matches for today
python live_odds.py list

# List only matches from Scotland and England
python live_odds.py list -f scotland england

2. Get Odds for a Specific Match

# Default simple text output
python live_odds.py odds "Celtic v Rangers"

# Pretty table output
python live_odds.py odds "Arsenal v Aston Villa" -p

# Nested dictionary (JSON) output
python live_odds.py odds "Man City v Chelsea" -d

Technical Fixes Implemented

This PR also resolves two critical API errors:

    TOO_MUCH_DATA API Error:

        Problem: Requesting odds for markets with many runners (e.g., CORRECT_SCORE) in a single API call exceeded Betfair's data limit.

        Solution: The script now fetches market catalogues first and then iterates through them, requesting the market_book (odds) for each market individually. This keeps each API call small and well within the limits.

    AttributeError: 'NoneType' and KeyError: 'market_type':

        Problem: The script was failing because market_catalogue.description was None, as this data was not being requested. This caused a downstream KeyError when trying to structure the dictionary output.

        Solution: Added "MARKET_DESCRIPTION" to the market_projection list in the list_market_catalogue API call. This ensures the necessary metadata is always available, fixing both errors.